### PR TITLE
Fix offset calculation for track private data

### DIFF
--- a/src/matroska.c
+++ b/src/matroska.c
@@ -174,6 +174,7 @@ int mk_writeHeader(mk_Writer *w, const char *writingApp)
 	w->seek_data.tracks = w->root->d_cur - w->segment_ptr;
 
 	if (w->tracks) {
+		offset = 0;
 		CHECK(mk_closeContext(w->tracks, &offset));
 		for (i = 0; i < w->num_tracks; i++) {
 			tk = w->tracks_arr[i];


### PR DESCRIPTION
When I de-shadowed offset, I forgot it needs to be zeroed before calling
mk_closeContext().  Otherwise it just adds to whatever the previous
value of offset was.
